### PR TITLE
curl_close() is deprecated, so I removed it

### DIFF
--- a/src/SimpleS3.php
+++ b/src/SimpleS3.php
@@ -260,7 +260,6 @@ class SimpleS3
         curl_setopt_array($ch, $curlOptions);
         $responseBody = curl_exec($ch);
         $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
 
         $success = $status !== 0 && $status !== 100 && $status !== 500 && $status !== 502 && $status !== 503;
         if ($responseBody === false || ! $success || curl_errno($ch) > 0) {


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
